### PR TITLE
Move git tools from toktok-stack.

### DIFF
--- a/tools/git-co
+++ b/tools/git-co
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec git checkout "$@"

--- a/tools/git-d
+++ b/tools/git-d
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec git diff "$@"

--- a/tools/git-s
+++ b/tools/git-s
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec git status "$@"

--- a/tools/git-ss
+++ b/tools/git-ss
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec git stack-status "$@"

--- a/tools/git-stack-status
+++ b/tools/git-stack-status
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Shows all the submodules that are not in their master branch, i.e. need to
+# have something merged before the stack PR can be merged.
+
+git submodule foreach --recursive --quiet \
+  'echo "$(git rev-parse --abbrev-ref HEAD): $path"' \
+  | grep -v master

--- a/tools/git-submit
+++ b/tools/git-submit
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+BRANCH=$1
+
+git checkout "$BRANCH"
+git push upstream "$BRANCH:master"
+git checkout master
+git merge upstream/master
+git push
+git branch -d "$BRANCH"
+git push origin ":$BRANCH"


### PR DESCRIPTION
All new git-* tools should live in the github-tools repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-github-tools/105)
<!-- Reviewable:end -->
