### PR TITLE
Add some missing fields to SimplePullRequest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: generic
+dist: xenial
 os: linux
 
 cache:

--- a/src/GitHub/Types/Base/SimplePullRequest.hs
+++ b/src/GitHub/Types/Base/SimplePullRequest.hs
@@ -11,45 +11,50 @@ import           Test.QuickCheck.Arbitrary          (Arbitrary (..))
 
 import           GitHub.Types.Base.Commit
 import           GitHub.Types.Base.DateTime
+import           GitHub.Types.Base.Label
 import           GitHub.Types.Base.Milestone
 import           GitHub.Types.Base.PullRequestLinks
+import           GitHub.Types.Base.Team
 import           GitHub.Types.Base.User
 
 ------------------------------------------------------------------------------
 -- SimplePullRequest
 
 data SimplePullRequest = SimplePullRequest
-    { simplePullRequestState             :: Text
-    , simplePullRequestReviewCommentUrl  :: Text
-    , simplePullRequestAssignees         :: [User]
-    , simplePullRequestAuthorAssociation :: Text
-    , simplePullRequestDraft             :: Bool
-    , simplePullRequestLocked            :: Bool
-    , simplePullRequestBase              :: Commit
-    , simplePullRequestBody              :: Text
-    , simplePullRequestHead              :: Commit
-    , simplePullRequestUrl               :: Text
-    , simplePullRequestMilestone         :: Maybe Milestone
-    , simplePullRequestStatusesUrl       :: Text
-    , simplePullRequestMergedAt          :: Maybe DateTime
-    , simplePullRequestCommitsUrl        :: Text
-    , simplePullRequestAssignee          :: Maybe User
-    , simplePullRequestDiffUrl           :: Text
-    , simplePullRequestUser              :: User
-    , simplePullRequestCommentsUrl       :: Text
-    , simplePullRequestLinks             :: PullRequestLinks
-    , simplePullRequestUpdatedAt         :: DateTime
-    , simplePullRequestPatchUrl          :: Text
-    , simplePullRequestCreatedAt         :: DateTime
-    , simplePullRequestId                :: Int
-    , simplePullRequestNodeId            :: Text
-    , simplePullRequestIssueUrl          :: Text
-    , simplePullRequestTitle             :: Text
-    , simplePullRequestClosedAt          :: Maybe DateTime
-    , simplePullRequestNumber            :: Int
-    , simplePullRequestMergeCommitSha    :: Maybe Text
-    , simplePullRequestReviewCommentsUrl :: Text
-    , simplePullRequestHtmlUrl           :: Text
+    { simplePullRequestState              :: Text
+    , simplePullRequestReviewCommentUrl   :: Text
+    , simplePullRequestAssignees          :: [User]
+    , simplePullRequestAuthorAssociation  :: Text
+    , simplePullRequestDraft              :: Bool
+    , simplePullRequestLocked             :: Bool
+    , simplePullRequestBase               :: Commit
+    , simplePullRequestBody               :: Text
+    , simplePullRequestHead               :: Commit
+    , simplePullRequestUrl                :: Text
+    , simplePullRequestMilestone          :: Maybe Milestone
+    , simplePullRequestStatusesUrl        :: Text
+    , simplePullRequestMergedAt           :: Maybe DateTime
+    , simplePullRequestCommitsUrl         :: Text
+    , simplePullRequestAssignee           :: Maybe User
+    , simplePullRequestDiffUrl            :: Text
+    , simplePullRequestUser               :: User
+    , simplePullRequestCommentsUrl        :: Text
+    , simplePullRequestLinks              :: PullRequestLinks
+    , simplePullRequestUpdatedAt          :: DateTime
+    , simplePullRequestPatchUrl           :: Text
+    , simplePullRequestCreatedAt          :: DateTime
+    , simplePullRequestId                 :: Int
+    , simplePullRequestNodeId             :: Text
+    , simplePullRequestIssueUrl           :: Text
+    , simplePullRequestTitle              :: Text
+    , simplePullRequestClosedAt           :: Maybe DateTime
+    , simplePullRequestNumber             :: Int
+    , simplePullRequestMergeCommitSha     :: Maybe Text
+    , simplePullRequestReviewCommentsUrl  :: Text
+    , simplePullRequestHtmlUrl            :: Text
+    , simplePullRequestRequestedReviewers :: [User]
+    , simplePullRequestRequestedTeams     :: [Team]
+    , simplePullRequestLabels             :: [Label]
     } deriving (Eq, Show, Read)
 
 
@@ -86,49 +91,58 @@ instance FromJSON SimplePullRequest where
         <*> x .: "merge_commit_sha"
         <*> x .: "review_comments_url"
         <*> x .: "html_url"
+        <*> x .: "requested_reviewers"
+        <*> x .: "requested_teams"
+        <*> x .: "labels"
 
     parseJSON _ = fail "SimplePullRequest"
 
 
 instance ToJSON SimplePullRequest where
     toJSON SimplePullRequest{..} = object
-        [ "state"               .= simplePullRequestState
-        , "review_comment_url"  .= simplePullRequestReviewCommentUrl
-        , "assignees"           .= simplePullRequestAssignees
-        , "author_association"  .= simplePullRequestAuthorAssociation
-        , "draft"               .= simplePullRequestDraft
-        , "locked"              .= simplePullRequestLocked
-        , "base"                .= simplePullRequestBase
-        , "body"                .= simplePullRequestBody
-        , "head"                .= simplePullRequestHead
-        , "url"                 .= simplePullRequestUrl
-        , "milestone"           .= simplePullRequestMilestone
-        , "statuses_url"        .= simplePullRequestStatusesUrl
-        , "merged_at"           .= simplePullRequestMergedAt
-        , "commits_url"         .= simplePullRequestCommitsUrl
-        , "assignee"            .= simplePullRequestAssignee
-        , "diff_url"            .= simplePullRequestDiffUrl
-        , "user"                .= simplePullRequestUser
-        , "comments_url"        .= simplePullRequestCommentsUrl
-        , "_links"              .= simplePullRequestLinks
-        , "updated_at"          .= simplePullRequestUpdatedAt
-        , "patch_url"           .= simplePullRequestPatchUrl
-        , "created_at"          .= simplePullRequestCreatedAt
-        , "id"                  .= simplePullRequestId
-        , "node_id"             .= simplePullRequestNodeId
-        , "issue_url"           .= simplePullRequestIssueUrl
-        , "title"               .= simplePullRequestTitle
-        , "closed_at"           .= simplePullRequestClosedAt
-        , "number"              .= simplePullRequestNumber
-        , "merge_commit_sha"    .= simplePullRequestMergeCommitSha
-        , "review_comments_url" .= simplePullRequestReviewCommentsUrl
-        , "html_url"            .= simplePullRequestHtmlUrl
+        [ "state"                .= simplePullRequestState
+        , "review_comment_url"   .= simplePullRequestReviewCommentUrl
+        , "assignees"            .= simplePullRequestAssignees
+        , "author_association"   .= simplePullRequestAuthorAssociation
+        , "draft"                .= simplePullRequestDraft
+        , "locked"               .= simplePullRequestLocked
+        , "base"                 .= simplePullRequestBase
+        , "body"                 .= simplePullRequestBody
+        , "head"                 .= simplePullRequestHead
+        , "url"                  .= simplePullRequestUrl
+        , "milestone"            .= simplePullRequestMilestone
+        , "statuses_url"         .= simplePullRequestStatusesUrl
+        , "merged_at"            .= simplePullRequestMergedAt
+        , "commits_url"          .= simplePullRequestCommitsUrl
+        , "assignee"             .= simplePullRequestAssignee
+        , "diff_url"             .= simplePullRequestDiffUrl
+        , "user"                 .= simplePullRequestUser
+        , "comments_url"         .= simplePullRequestCommentsUrl
+        , "_links"               .= simplePullRequestLinks
+        , "updated_at"           .= simplePullRequestUpdatedAt
+        , "patch_url"            .= simplePullRequestPatchUrl
+        , "created_at"           .= simplePullRequestCreatedAt
+        , "id"                   .= simplePullRequestId
+        , "node_id"              .= simplePullRequestNodeId
+        , "issue_url"            .= simplePullRequestIssueUrl
+        , "title"                .= simplePullRequestTitle
+        , "closed_at"            .= simplePullRequestClosedAt
+        , "number"               .= simplePullRequestNumber
+        , "merge_commit_sha"     .= simplePullRequestMergeCommitSha
+        , "review_comments_url"  .= simplePullRequestReviewCommentsUrl
+        , "html_url"             .= simplePullRequestHtmlUrl
+        , "requested_reviewers"  .= simplePullRequestRequestedReviewers
+        , "requested_teams"      .= simplePullRequestRequestedTeams
+        , "labels"               .= simplePullRequestLabels
         ]
 
 
 instance Arbitrary SimplePullRequest where
     arbitrary = SimplePullRequest
         <$> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary


### PR DESCRIPTION
This is the version of "pull_request" that we get in
"pull_request_review" events. The complete PullRequest is only received
in "pull_request" events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-github-tools/110)
<!-- Reviewable:end -->
