### PR TITLE
Remove warning flags. These are now default.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,8 +10,6 @@ haskell_library(
     srcs = glob(["src/**/*.*hs"]),
     compiler_flags = [
         "-j4",
-        "-Wall",
-        "-Werror",
         "-Wno-unused-imports",
     ],
     src_strip_prefix = "src",
@@ -51,8 +49,6 @@ hspec_test(
     compiler_flags = [
         "-threaded",
         "-rtsopts",
-        "-Wall",
-        "-Werror",
         "-Wno-unused-imports",
     ],
     deps = [


### PR DESCRIPTION
toktok-stack sets default `-Wall -Werror.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-github-tools/112)
<!-- Reviewable:end -->
