### PR TITLE
Reduce number of testcases for property tests to 20.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,8 +39,8 @@ haskell_library(
 )
 
 hspec_test(
-    name = "test",
-    timeout = "long",
+    name = "testsuite",
+    size = "small",
     args = [
         "-j4",
         "+RTS",

--- a/github-tools.cabal
+++ b/github-tools.cabal
@@ -108,6 +108,8 @@ library
       Requests
   ghc-options:
       -Wall
+  hs-source-dirs:      src
+  default-language:    Haskell2010
   build-depends:
       base >= 4 && < 5
     , aeson             >= 0.8.1.0
@@ -116,7 +118,6 @@ library
     , cryptohash
     , exceptions
     , github            == 0.25
-    , groom
     , html
     , http-client       >= 0.4.30
     , http-client-tls
@@ -129,52 +130,55 @@ library
     , unordered-containers
     , uuid
     , vector
-  hs-source-dirs:      src
-  default-language:    Haskell2010
 
 executable hub-pulls
   main-is:             hub-pulls.hs
   ghc-options:
       -Wall
+  hs-source-dirs:      tools
+  default-language:    Haskell2010
   build-depends:
       base >= 4 && < 5
     , bytestring
     , github            == 0.25
     , github-tools
     , text
-  hs-source-dirs:      tools
-  default-language:    Haskell2010
 
 executable hub-changelog
   main-is:             hub-changelog.hs
   ghc-options:
       -Wall
+  hs-source-dirs:      tools
+  default-language:    Haskell2010
   build-depends:
       base >= 4 && < 5
     , bytestring
     , github            == 0.25
     , github-tools
     , text
-  hs-source-dirs:      tools
-  default-language:    Haskell2010
 
 executable hub-roadmap
   main-is:             hub-roadmap.hs
   ghc-options:
       -Wall
+  hs-source-dirs:      tools
+  default-language:    Haskell2010
   build-depends:
       base >= 4 && < 5
     , bytestring
     , github            == 0.25
     , github-tools
     , text
-  hs-source-dirs:      tools
-  default-language:    Haskell2010
 
 executable webservice
   main-is:             webservice.hs
   ghc-options:
       -Wall
+  hs-source-dirs:      web
+  default-language:    Haskell2010
+  other-modules:
+      TokTok.Hello
+      TokTok.Webhooks
   build-depends:
       base >= 4 && < 5
     , Diff
@@ -197,11 +201,6 @@ executable webservice
     , wai-cors
     , wai-extra
     , warp
-  hs-source-dirs:      web
-  default-language:    Haskell2010
-  other-modules:
-      TokTok.Hello
-      TokTok.Webhooks
 
 test-suite testsuite
   type: exitcode-stdio-1.0

--- a/test/GitHub/Types/BaseSpec.hs
+++ b/test/GitHub/Types/BaseSpec.hs
@@ -3,11 +3,13 @@
 module GitHub.Types.BaseSpec where
 
 import           Data.Aeson        (decode, encode)
-import           Test.Hspec
-import           Test.QuickCheck
+import           Test.Hspec        (Spec, describe, it, parallel, shouldBe)
+import qualified Test.QuickCheck   as QC
 
 import           GitHub.Types.Base
 
+property :: QC.Testable prop => prop -> QC.Property
+property = QC.withMaxSuccess 20 . QC.property
 
 spec :: Spec
 spec =

--- a/test/GitHub/Types/EventsSpec.hs
+++ b/test/GitHub/Types/EventsSpec.hs
@@ -3,10 +3,13 @@
 module GitHub.Types.EventsSpec where
 
 import           Data.Aeson          (decode, encode)
-import           Test.Hspec
-import           Test.QuickCheck
+import           Test.Hspec          (Spec, describe, it, parallel, shouldBe)
+import qualified Test.QuickCheck     as QC
 
 import           GitHub.Types.Events
+
+property :: QC.Testable prop => prop -> QC.Property
+property = QC.withMaxSuccess 20 . QC.property
 
 
 spec :: Spec


### PR DESCRIPTION
It was 100, and took several minutes to complete. With 10, it takes 0.2
seconds, with 20, it takes 4.5 seconds. This is a reasonable tradeoff
between time spent running the test and its exhaustiveness. Most of the
time we find the errors within the first 10 tests anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-github-tools/113)
<!-- Reviewable:end -->
