### PR TITLE
perf: Use StrictData for all modules that define data types.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+---
+cirrus-ci_task:
+  container:
+    image: toxchat/toktok-stack:0.0.19
+    cpu: 2
+    memory: 6G
+  configure_script:
+    - /src/workspace/tools/inject-repo hs-github-tools
+  test_all_script:
+    - bazel test -k
+        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+        --config=release
+        //hs-github-tools/...

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,7 +12,6 @@ branches:
     protection:
       required_status_checks:
         contexts:
-          - Codacy/PR Quality Review
-          - Travis CI - Pull Request
-          - code-review/reviewable
-          - coverage/coveralls
+          - "cirrus-ci"
+          - "Codacy Static Code Analysis"
+          - "code-review/reviewable"

--- a/src/Changelogs.hs
+++ b/src/Changelogs.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData        #-}
 module Changelogs
   ( fetchChangeLog
   , formatChangeLog

--- a/src/GitHub/Types/Base/Author.hs
+++ b/src/GitHub/Types/Base/Author.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Author where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Branch.hs
+++ b/src/GitHub/Types/Base/Branch.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Branch where
 
 import           Control.Applicative         ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Change.hs
+++ b/src/GitHub/Types/Base/Change.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Change where
 
 import           Control.Applicative       ((<$>))

--- a/src/GitHub/Types/Base/Changes.hs
+++ b/src/GitHub/Types/Base/Changes.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Changes where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CheckApp.hs
+++ b/src/GitHub/Types/Base/CheckApp.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CheckApp where
 
 import           Control.Applicative           ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CheckCommit.hs
+++ b/src/GitHub/Types/Base/CheckCommit.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CheckCommit where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CheckOutput.hs
+++ b/src/GitHub/Types/Base/CheckOutput.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CheckOutput where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CheckRun.hs
+++ b/src/GitHub/Types/Base/CheckRun.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CheckRun where
 
 import           Control.Applicative           ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CheckSuite.hs
+++ b/src/GitHub/Types/Base/CheckSuite.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CheckSuite where
 
 import           Control.Applicative           ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Commit.hs
+++ b/src/GitHub/Types/Base/Commit.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Commit where
 
 import           Control.Applicative          ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CommitComment.hs
+++ b/src/GitHub/Types/Base/CommitComment.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CommitComment where
 
 import           Control.Applicative        ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CommitDetails.hs
+++ b/src/GitHub/Types/Base/CommitDetails.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CommitDetails where
 
 import           Control.Applicative            ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CommitRef.hs
+++ b/src/GitHub/Types/Base/CommitRef.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CommitRef where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/CommitRefHtml.hs
+++ b/src/GitHub/Types/Base/CommitRefHtml.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.CommitRefHtml where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/DateTime.hs
+++ b/src/GitHub/Types/Base/DateTime.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module GitHub.Types.Base.DateTime where
 
 import           Control.Applicative       ((<$>), (<|>))

--- a/src/GitHub/Types/Base/Deployment.hs
+++ b/src/GitHub/Types/Base/Deployment.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Deployment where
 
 import           Control.Applicative                 ((<$>), (<*>))

--- a/src/GitHub/Types/Base/DeploymentPayload.hs
+++ b/src/GitHub/Types/Base/DeploymentPayload.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.DeploymentPayload where
 
 import           Control.Applicative       ((<$>))

--- a/src/GitHub/Types/Base/DeploymentStatus.hs
+++ b/src/GitHub/Types/Base/DeploymentStatus.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.DeploymentStatus where
 
 import           Control.Applicative        ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Hook.hs
+++ b/src/GitHub/Types/Base/Hook.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Hook where
 
 import           Control.Applicative          ((<$>), (<*>))

--- a/src/GitHub/Types/Base/HookConfig.hs
+++ b/src/GitHub/Types/Base/HookConfig.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.HookConfig where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Installation.hs
+++ b/src/GitHub/Types/Base/Installation.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Installation where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Invitation.hs
+++ b/src/GitHub/Types/Base/Invitation.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Invitation where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Issue.hs
+++ b/src/GitHub/Types/Base/Issue.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Issue where
 
 import           Control.Applicative              ((<$>), (<*>))

--- a/src/GitHub/Types/Base/IssueComment.hs
+++ b/src/GitHub/Types/Base/IssueComment.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.IssueComment where
 
 import           Control.Applicative        ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Label.hs
+++ b/src/GitHub/Types/Base/Label.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Label where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/License.hs
+++ b/src/GitHub/Types/Base/License.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.License where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Link.hs
+++ b/src/GitHub/Types/Base/Link.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Link where
 
 import           Control.Applicative       ((<$>))

--- a/src/GitHub/Types/Base/Membership.hs
+++ b/src/GitHub/Types/Base/Membership.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Membership where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Milestone.hs
+++ b/src/GitHub/Types/Base/Milestone.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Milestone where
 
 import           Control.Applicative        ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Organization.hs
+++ b/src/GitHub/Types/Base/Organization.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Organization where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/PageBuild.hs
+++ b/src/GitHub/Types/Base/PageBuild.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.PageBuild where
 
 import           Control.Applicative              ((<$>), (<*>))

--- a/src/GitHub/Types/Base/PageBuildError.hs
+++ b/src/GitHub/Types/Base/PageBuildError.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.PageBuildError where
 
 import           Control.Applicative       ((<$>))

--- a/src/GitHub/Types/Base/Permissions.hs
+++ b/src/GitHub/Types/Base/Permissions.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Permissions where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/PullRequest.hs
+++ b/src/GitHub/Types/Base/PullRequest.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.PullRequest where
 
 import           Control.Applicative                ((<$>), (<*>))

--- a/src/GitHub/Types/Base/PullRequestLinks.hs
+++ b/src/GitHub/Types/Base/PullRequestLinks.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.PullRequestLinks where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/PullRequestRef.hs
+++ b/src/GitHub/Types/Base/PullRequestRef.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.PullRequestRef where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/PushCommit.hs
+++ b/src/GitHub/Types/Base/PushCommit.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.PushCommit where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Release.hs
+++ b/src/GitHub/Types/Base/Release.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Release where
 
 import           Control.Applicative        ((<$>), (<*>))

--- a/src/GitHub/Types/Base/RepoOwner.hs
+++ b/src/GitHub/Types/Base/RepoOwner.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module GitHub.Types.Base.RepoOwner where
 
 import           Control.Applicative       ((<$>), (<|>))

--- a/src/GitHub/Types/Base/Repository.hs
+++ b/src/GitHub/Types/Base/Repository.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Repository where
 
 import           Control.Applicative         ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Review.hs
+++ b/src/GitHub/Types/Base/Review.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Review where
 
 import           Control.Applicative           ((<$>), (<*>))

--- a/src/GitHub/Types/Base/ReviewComment.hs
+++ b/src/GitHub/Types/Base/ReviewComment.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.ReviewComment where
 
 import           Control.Applicative                  ((<$>), (<*>))

--- a/src/GitHub/Types/Base/ReviewCommentLinks.hs
+++ b/src/GitHub/Types/Base/ReviewCommentLinks.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.ReviewCommentLinks where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/ReviewLinks.hs
+++ b/src/GitHub/Types/Base/ReviewLinks.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.ReviewLinks where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/SimplePullRequest.hs
+++ b/src/GitHub/Types/Base/SimplePullRequest.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.SimplePullRequest where
 
 import           Control.Applicative                ((<$>), (<*>))

--- a/src/GitHub/Types/Base/StatusCommit.hs
+++ b/src/GitHub/Types/Base/StatusCommit.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.StatusCommit where
 
 import           Control.Applicative             ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Team.hs
+++ b/src/GitHub/Types/Base/Team.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Team where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/User.hs
+++ b/src/GitHub/Types/Base/User.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.User where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/UserRef.hs
+++ b/src/GitHub/Types/Base/UserRef.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.UserRef where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/UserStamp.hs
+++ b/src/GitHub/Types/Base/UserStamp.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.UserStamp where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Base/Verification.hs
+++ b/src/GitHub/Types/Base/Verification.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Base.Verification where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Event.hs
+++ b/src/GitHub/Types/Event.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module GitHub.Types.Event where
 
 import           Data.Text (Text)

--- a/src/GitHub/Types/Events/CheckRunEvent.hs
+++ b/src/GitHub/Types/Events/CheckRunEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.CheckRunEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/CheckSuiteEvent.hs
+++ b/src/GitHub/Types/Events/CheckSuiteEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.CheckSuiteEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/CommitCommentEvent.hs
+++ b/src/GitHub/Types/Events/CommitCommentEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.CommitCommentEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/CreateEvent.hs
+++ b/src/GitHub/Types/Events/CreateEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.CreateEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/DeleteEvent.hs
+++ b/src/GitHub/Types/Events/DeleteEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.DeleteEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/DeploymentEvent.hs
+++ b/src/GitHub/Types/Events/DeploymentEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.DeploymentEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/DeploymentStatusEvent.hs
+++ b/src/GitHub/Types/Events/DeploymentStatusEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.DeploymentStatusEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/ForkEvent.hs
+++ b/src/GitHub/Types/Events/ForkEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.ForkEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/GollumEvent.hs
+++ b/src/GitHub/Types/Events/GollumEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.GollumEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/IssueCommentEvent.hs
+++ b/src/GitHub/Types/Events/IssueCommentEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.IssueCommentEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/IssuesEvent.hs
+++ b/src/GitHub/Types/Events/IssuesEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.IssuesEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/LabelEvent.hs
+++ b/src/GitHub/Types/Events/LabelEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.LabelEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/MemberEvent.hs
+++ b/src/GitHub/Types/Events/MemberEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.MemberEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/MembershipEvent.hs
+++ b/src/GitHub/Types/Events/MembershipEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.MembershipEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/MilestoneEvent.hs
+++ b/src/GitHub/Types/Events/MilestoneEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.MilestoneEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/OrganizationEvent.hs
+++ b/src/GitHub/Types/Events/OrganizationEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.OrganizationEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/PageBuildEvent.hs
+++ b/src/GitHub/Types/Events/PageBuildEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.PageBuildEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/PingEvent.hs
+++ b/src/GitHub/Types/Events/PingEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.PingEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/PullRequestEvent.hs
+++ b/src/GitHub/Types/Events/PullRequestEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.PullRequestEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/PullRequestReviewCommentEvent.hs
+++ b/src/GitHub/Types/Events/PullRequestReviewCommentEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.PullRequestReviewCommentEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/PullRequestReviewEvent.hs
+++ b/src/GitHub/Types/Events/PullRequestReviewEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.PullRequestReviewEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/PushEvent.hs
+++ b/src/GitHub/Types/Events/PushEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.PushEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/ReleaseEvent.hs
+++ b/src/GitHub/Types/Events/ReleaseEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.ReleaseEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/RepositoryEvent.hs
+++ b/src/GitHub/Types/Events/RepositoryEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.RepositoryEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/StarEvent.hs
+++ b/src/GitHub/Types/Events/StarEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.StarEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/StatusEvent.hs
+++ b/src/GitHub/Types/Events/StatusEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.StatusEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/Events/WatchEvent.hs
+++ b/src/GitHub/Types/Events/WatchEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
 module GitHub.Types.Events.WatchEvent where
 
 import           Control.Applicative       ((<$>), (<*>))

--- a/src/GitHub/Types/PayloadParser.hs
+++ b/src/GitHub/Types/PayloadParser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module GitHub.Types.PayloadParser where
 
 import           Data.Aeson          (FromJSON (..), ToJSON (..))

--- a/src/GitHub/WebHook/Handler.hs
+++ b/src/GitHub/WebHook/Handler.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData        #-}
 {-# LANGUAGE TupleSections     #-}
 module GitHub.WebHook.Handler
   ( Handler (..)

--- a/src/PullRequestInfo.hs
+++ b/src/PullRequestInfo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData        #-}
 module PullRequestInfo where
 
 import           Control.Monad         (join)

--- a/web/TokTok/Hello.hs
+++ b/web/TokTok/Hello.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 module TokTok.Hello (newApp) where


### PR DESCRIPTION
I've added StrictData to some modules that don't currently define data
types, mostly by mistake, but it doesn't harm and avoids missing it in
the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-github-tools/121)
<!-- Reviewable:end -->
