### PR TITLE
chore: Upload only installed binaries into the docker image.

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,6 +1,10 @@
 # hadolint ignore=DL3007
-FROM toxchat/haskell:latest
+FROM toxchat/haskell:latest AS build
 
 RUN ["rm", "-rf", "/work/hs-github-tools"]
 COPY --chown=builder:users . /work/hs-github-tools
-RUN ["stack", "build", "github-tools"]
+RUN ["stack", "install", "github-tools"]
+
+FROM scratch
+
+COPY --from=build /home/builder/.local/ /

--- a/.github/docker/Dockerfile.heroku
+++ b/.github/docker/Dockerfile.heroku
@@ -1,6 +1,4 @@
 FROM toxchat/haskell:hs-github-tools AS build
-RUN ["stack", "install", "github-tools"]
-
 FROM ubuntu:20.04
 
 RUN apt-get update \


### PR DESCRIPTION
This greatly speeds up the heroku build following the docker image
build, because it doesn't need to download the haskell compiler etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-github-tools/140)
<!-- Reviewable:end -->
