### PR TITLE
chore: Limit aeson version compatibility.

### DIFF
--- a/github-tools.cabal
+++ b/github-tools.cabal
@@ -115,7 +115,7 @@ library
   default-language:    Haskell2010
   build-depends:
       base >= 4 && < 5
-    , aeson             >= 0.8.1.0
+    , aeson             >= 0.8.1.0 && < 2
     , bytestring
     , containers
     , cryptohash


### PR DESCRIPTION
aeson 2 introduced incompatible changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-github-tools/151)
<!-- Reviewable:end -->
