### PR TITLE
fix: Make automerge work when fork repo name != base repo name.

### DIFF
--- a/src/GitHub/Tools/AutoMerge.hs
+++ b/src/GitHub/Tools/AutoMerge.hs
@@ -57,7 +57,7 @@ autoMerge token ownerName PullRequestInfo{prRepoName, prUser, prBranch, prOrigin
 
     callProcess "git"
         [ "remote", "add", "upstream"
-        , "https://" <> token <> "@github.com/" <> Text.unpack (GitHub.untagName ownerName) <> "/" <> Text.unpack prOrigin
+        , "https://" <> token <> "@github.com/" <> Text.unpack (GitHub.untagName ownerName) <> "/" <> Text.unpack prRepoName
         ]
     callProcess "git"
         [ "push", "upstream", Text.unpack prBranch <> ":master" ]

--- a/src/GitHub/Tools/PullStatus.hs
+++ b/src/GitHub/Tools/PullStatus.hs
@@ -74,7 +74,7 @@ makePullRequestInfo repoName (reviewers, pr) = PullRequestInfo
   , prTitle       = GitHub.pullRequestTitle pr
   , prReviewers   = reviewers
   , prState       = showMergeableState $ GitHub.pullRequestMergeableState pr
-  , prOrigin      = GitHub.untagName . GitHub.repoName <$> GitHub.pullRequestCommitRepo (GitHub.pullRequestBase pr)
+  , prOrigin      = GitHub.untagName . GitHub.repoName <$> GitHub.pullRequestCommitRepo (GitHub.pullRequestHead pr)
   -- TODO(iphydf): The Haskell github package doesn't support this yet.
   -- , prTrustworthy = GitHub.pullRequestAuthorAssociation pr
   , prTrustworthy = False


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-github-tools/165)
<!-- Reviewable:end -->
