### PR TITLE
chore: Remove codeql from toktok-stack for now.

### DIFF
--- a/admin/settings.yaml
+++ b/admin/settings.yaml
@@ -944,9 +944,6 @@ toktok-stack:
           - "code-review/reviewable"
           - "restyled"
           # Custom
-          - "Analyze (go)"
-          - "Analyze (python)"
-          - "CodeQL"
           - "common / buildifier"
           - "docker-haskell"
           - "docker-test"


### PR DESCRIPTION
It's broken. I'll fix it later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-github-tools/192)
<!-- Reviewable:end -->
