### PR TITLE
chore: Clean up jvm-toxcore-c CI checks.

### DIFF
--- a/admin/settings.yaml
+++ b/admin/settings.yaml
@@ -884,7 +884,8 @@ jvm-toxcore-c:
           # Custom
           - "CodeFactor"
           - "bazel-opt"
-          - "docker-jvm"
+          - "docker (jvm)"
+          - "docker (native)"
 
 py-toxcore-c:
   editRepo:

--- a/src/GitHub/WebHook/Handler.hs
+++ b/src/GitHub/WebHook/Handler.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports    #-}
 {-# LANGUAGE StrictData        #-}
 {-# LANGUAGE TupleSections     #-}
 module GitHub.WebHook.Handler
@@ -8,19 +9,19 @@ module GitHub.WebHook.Handler
   , removeNulls
   ) where
 
-import           Crypto.Hash           (HMAC, SHA1, digestToHexByteString, hmac,
-                                        hmacGetDigest)
-import           Data.Aeson            (ToJSON (..), Value (..),
-                                        eitherDecodeStrict')
-import qualified Data.Aeson.KeyMap     as KeyMap
-import           Data.Aeson.Types      (parseEither)
-import           Data.ByteString       (ByteString)
-import qualified Data.ByteString.Char8 as BC8
-import           Data.Text             (Text)
-import qualified Data.Text             as Text
-import           Data.Text.Encoding    (decodeUtf8)
-import           Data.UUID             (UUID, fromASCIIBytes)
-import qualified Data.Vector           as Vector
+import           "cryptohash" Crypto.Hash (HMAC, SHA1, digestToHexByteString,
+                                           hmac, hmacGetDigest)
+import           Data.Aeson               (ToJSON (..), Value (..),
+                                           eitherDecodeStrict')
+import qualified Data.Aeson.KeyMap        as KeyMap
+import           Data.Aeson.Types         (parseEither)
+import           Data.ByteString          (ByteString)
+import qualified Data.ByteString.Char8    as BC8
+import           Data.Text                (Text)
+import qualified Data.Text                as Text
+import           Data.Text.Encoding       (decodeUtf8)
+import           Data.UUID                (UUID, fromASCIIBytes)
+import qualified Data.Vector              as Vector
 
 import           GitHub.Types
 


### PR DESCRIPTION
The jvm-toxcore-c ones were renamed a while back.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-github-tools/201)
<!-- Reviewable:end -->
