### PR TITLE
chore: Remove the native kmp build from jvm-toxcore-c

### DIFF
--- a/admin/repos.yaml
+++ b/admin/repos.yaml
@@ -986,7 +986,6 @@ jvm-toxcore-c:
           - "CodeFactor"
           - "bazel-opt"
           - "docker (jvm)"
-          - "docker (native)"
 
 py-toxcore-c:
   editRepo:


### PR DESCRIPTION
We're switching to a normal jvm build there for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-github-tools/210)
<!-- Reviewable:end -->
